### PR TITLE
Handle deletion of missing categories and surface image load errors

### DIFF
--- a/image_categorizer/infrastructure/local_filesystem.py
+++ b/image_categorizer/infrastructure/local_filesystem.py
@@ -11,8 +11,10 @@ class LocalFileSystem(IFileSystem):
         path.mkdir(parents=True, exist_ok=True)
     def delete_dir_if_empty(self, path: Path) -> bool:
         try:
-            if not path.exists(): 
-                return True
+            # If the directory doesn't exist we should report failure
+            # so callers can handle missing categories appropriately.
+            if not path.exists():
+                return False
             if any(path.iterdir()):
                 return False
             path.rmdir()

--- a/image_categorizer/infrastructure/repositories.py
+++ b/image_categorizer/infrastructure/repositories.py
@@ -17,7 +17,11 @@ class CategoryRepository(ICategoryRepository):
         self._logger.info(f"Category created: {name}")
 
     def delete_category_if_empty(self, root: Path, name: str) -> bool:
-        ok = self._fs.delete_dir_if_empty(root / name)
+        path = root / name
+        if not self._fs.exists(path):
+            self._logger.warn(f"Category not found: {name}")
+            return False
+        ok = self._fs.delete_dir_if_empty(path)
         if ok:
             self._logger.info(f"Category deleted: {name}")
         else:

--- a/image_categorizer/ui/app_controller.py
+++ b/image_categorizer/ui/app_controller.py
@@ -86,5 +86,6 @@ class AppController:
             self._logger.error(str(ex))
             self._view.set_status("Failed to load image; buttons disabled.")
             self._view.button_panel.set_enabled(False)
+            self._view.error("Image Load Error", str(ex))
 
         self._view.set_remaining_count(self._img_svc.count_images())

--- a/image_categorizer/ui/collision_dialog.py
+++ b/image_categorizer/ui/collision_dialog.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox
 from PIL import ImageTk
 from pathlib import Path
 from typing import Optional
@@ -96,8 +96,8 @@ class CollisionDialog(tk.Toplevel):
             self._canvas_right.delete("all")
             self._canvas_left.create_image((lw - self._img_left.width())//2, (lh - self._img_left.height())//2, anchor="nw", image=self._img_left)
             self._canvas_right.create_image((rw - self._img_right.width())//2, (rh - self._img_right.height())//2, anchor="nw", image=self._img_right)
-        except Exception:
-            pass
+        except Exception as ex:
+            messagebox.showerror("Image Load Error", str(ex))
 
     @staticmethod
     def prompt(parent, image_loader: IImageLoader, source_path: Path, target_path: Path) -> "CollisionDecision":

--- a/tests/test_category_deletion.py
+++ b/tests/test_category_deletion.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is on the path when running tests directly.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import types
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+
+from image_categorizer.infrastructure import LocalFileSystem, CategoryRepository, ConsoleLogger
+from image_categorizer.services import CategoryService
+
+
+def test_delete_nonexistent_category_returns_false(tmp_path, capsys):
+    logger = ConsoleLogger()
+    fs = LocalFileSystem()
+    repo = CategoryRepository(fs, logger)
+    svc = CategoryService(tmp_path, repo, fs, logger)
+
+    result = svc.delete_category("missing")
+
+    out = capsys.readouterr().out
+    assert "Category not found: missing" in out
+    assert result is False

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import sys
+import types
+
+# Provide dummy PIL modules so imports succeed without pillow installed
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+
+from image_categorizer.ui.app_controller import AppController
+from image_categorizer.exceptions import ImageLoadError
+
+class DummyImageView:
+    def show_image(self, path):
+        raise ImageLoadError("boom")
+
+class DummyButtonPanel:
+    def __init__(self):
+        self.enabled = None
+    def set_enabled(self, value):
+        self.enabled = value
+
+class DummyView:
+    def __init__(self):
+        self.image_view = DummyImageView()
+        self.button_panel = DummyButtonPanel()
+        self.error_called = []
+        self.status = None
+        self.remaining = None
+    def set_status(self, text):
+        self.status = text
+    def error(self, title, message):
+        self.error_called.append((title, message))
+    def set_remaining_count(self, n):
+        self.remaining = n
+
+class DummyImageService:
+    def advance_to_first(self):
+        pass
+    def current_image(self):
+        return Path("foo.jpg")
+    def count_images(self):
+        return 0
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+    def error(self, msg):
+        self.messages.append(msg)
+
+
+def test_post_load_shows_error_dialog():
+    controller = AppController.__new__(AppController)
+    controller._view = DummyView()
+    controller._logger = DummyLogger()
+    controller._img_svc = DummyImageService()
+    controller._cat_svc = None
+    controller._image_loader = None
+    controller._fs = None
+    controller._cfg = None
+    controller._root = None
+    controller._post_load()
+    assert controller._view.button_panel.enabled is False
+    assert controller._view.error_called == [("Image Load Error", "boom")]
+    assert controller._view.status == "Failed to load image; buttons disabled."


### PR DESCRIPTION
## Summary
- prevent LocalFileSystem.delete_dir_if_empty from succeeding on missing directories
- log and fail when attempting to delete a non-existent category
- add regression test for deleting a missing category
- show dialog when CollisionDialog fails to load preview images
- report image load failures via MainView.error and test the behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50b7e85e08327895c0185e930aca2