### PR TITLE
feat: make image resize filter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ Run:
 pip install -r requirements.txt
 pythonw app.pyw  # use pythonw to avoid opening a console window on Windows
 ```
+
+## Image resizing quality vs. speed
+
+`PillowImageLoader` uses Pillow's ``BILINEAR`` filter by default which is
+considerably faster than ``LANCZOS`` while keeping reasonable quality.
+For highest quality at the cost of performance, construct the loader with
+``Image.LANCZOS``; for maximum speed use ``Image.NEAREST``. Example:
+
+```python
+from PIL import Image
+from image_categorizer.infrastructure import PillowImageLoader
+
+img_loader = PillowImageLoader(resample=Image.LANCZOS)
+```

--- a/image_categorizer/infrastructure/pillow_image_loader.py
+++ b/image_categorizer/infrastructure/pillow_image_loader.py
@@ -3,7 +3,34 @@ from typing import Tuple
 from PIL import Image
 from ..interfaces.image_loader import IImageLoader
 
+# Pillow 10 moved resampling filters under Image.Resampling.  Fall back to the
+# old module-level constants when unavailable.
+if hasattr(Image, "Resampling"):
+    DEFAULT_RESAMPLE = Image.Resampling.BILINEAR
+elif hasattr(Image, "BILINEAR"):
+    DEFAULT_RESAMPLE = Image.BILINEAR
+else:  # numeric value for BILINEAR used by Pillow
+    DEFAULT_RESAMPLE = 2
+
+
 class PillowImageLoader(IImageLoader):
+    """Load images and resize them while preserving aspect ratio.
+
+    The loader defaults to :pydata:`PIL.Image.BILINEAR` for a balance between
+    quality and performance.  Higher quality filters such as
+    :pydata:`PIL.Image.LANCZOS` can be selected at the cost of slower
+    processing, while :pydata:`PIL.Image.NEAREST` is faster but produces
+    noticeably lower quality results.
+
+    Parameters
+    ----------
+    resample : int, optional
+        Resampling filter from ``PIL.Image``. Defaults to ``Image.BILINEAR``.
+    """
+
+    def __init__(self, resample: int = DEFAULT_RESAMPLE):
+        self._resample = resample
+
     def load_and_fit(self, path: Path, target_size: Tuple[int, int]):
         with Image.open(path) as img:
             img = img.convert("RGBA")
@@ -11,6 +38,6 @@ class PillowImageLoader(IImageLoader):
             if tw <= 0 or th <= 0:
                 return img
             iw, ih = img.size
-            scale = min(tw/iw, th/ih)
-            new_size = (max(1, int(iw*scale)), max(1, int(ih*scale)))
-            return img.resize(new_size, Image.LANCZOS)
+            scale = min(tw / iw, th / ih)
+            new_size = (max(1, int(iw * scale)), max(1, int(ih * scale)))
+            return img.resize(new_size, self._resample)


### PR DESCRIPTION
## Summary
- allow PillowImageLoader to use a configurable resampling filter
- document resizing quality vs. speed trade-offs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51a4594808327a2dec6013cfefeea