### PR TITLE
Add display and fast image loaders

### DIFF
--- a/app.pyw
+++ b/app.pyw
@@ -1,7 +1,14 @@
 import tkinter as tk
 from pathlib import Path
+from PIL import Image
 from image_categorizer.config import AppConfig
-from image_categorizer.infrastructure import ConsoleLogger, LocalFileSystem, PillowImageLoader, CategoryRepository, ImageRepository
+from image_categorizer.infrastructure import (
+    ConsoleLogger,
+    LocalFileSystem,
+    PillowImageLoader,
+    CategoryRepository,
+    ImageRepository,
+)
 from image_categorizer.services import CategoryService, ImageService
 from image_categorizer.ui import MainView, AppController
 
@@ -18,13 +25,14 @@ def main():
 
     logger = ConsoleLogger()
     fs = LocalFileSystem()
-    img_loader = PillowImageLoader()
+    display_loader = PillowImageLoader(resample=Image.LANCZOS)
+    fast_loader = PillowImageLoader(resample=Image.NEAREST)
     cat_repo = CategoryRepository(fs, logger)
     img_repo = ImageRepository(fs, logger)
     cat_svc = CategoryService(root_dir, cat_repo, fs, logger)
     img_svc = ImageService(root_dir, img_repo, fs, logger)
 
-    AppController(view, logger, img_loader, cat_svc, img_svc, fs, cfg, root_dir)
+    AppController(view, logger, display_loader, fast_loader, cat_svc, img_svc, fs, cfg, root_dir)
     root.mainloop()
 
 if __name__ == "__main__":

--- a/image_categorizer/infrastructure/pillow_image_loader.py
+++ b/image_categorizer/infrastructure/pillow_image_loader.py
@@ -3,7 +3,16 @@ from typing import Tuple
 from PIL import Image
 from ..interfaces.image_loader import IImageLoader
 
+try:  # pragma: no cover - allow tests without pillow installed
+    _DEFAULT_RESAMPLE = Image.LANCZOS
+except AttributeError:  # when PIL is stubbed in tests
+    _DEFAULT_RESAMPLE = None
+
+
 class PillowImageLoader(IImageLoader):
+    def __init__(self, *, resample=_DEFAULT_RESAMPLE):
+        self._resample = resample if resample is not None else Image.NEAREST
+
     def load_and_fit(self, path: Path, target_size: Tuple[int, int]):
         with Image.open(path) as img:
             img = img.convert("RGBA")
@@ -12,5 +21,5 @@ class PillowImageLoader(IImageLoader):
                 return img
             iw, ih = img.size
             scale = min(tw/iw, th/ih)
-            new_size = (max(1, int(iw*scale)), max(1, int(ih*scale)))
-            return img.resize(new_size, Image.LANCZOS)
+            new_size = (max(1, int(iw * scale)), max(1, int(ih * scale)))
+            return img.resize(new_size, self._resample)

--- a/image_categorizer/ui/app_controller.py
+++ b/image_categorizer/ui/app_controller.py
@@ -13,12 +13,24 @@ from .button_panel import ButtonPanel
 from .settings_view import SettingsView
 from .collision_dialog import CollisionDialog
 
+
 class AppController:
-    def __init__(self, view: MainView, logger: ILogger, image_loader: IImageLoader,
-                 cat_svc: ICategoryService, img_svc: IImageService, fs: IFileSystem, config: AppConfig, root_dir: Path):
+    def __init__(
+        self,
+        view: MainView,
+        logger: ILogger,
+        display_loader: IImageLoader,
+        fast_loader: IImageLoader,
+        cat_svc: ICategoryService,
+        img_svc: IImageService,
+        fs: IFileSystem,
+        config: AppConfig,
+        root_dir: Path,
+    ):
         self._view = view
         self._logger = logger
-        self._image_loader = image_loader
+        self._display_loader = display_loader
+        self._fast_loader = fast_loader
         self._cat_svc = cat_svc
         self._img_svc = img_svc
         self._fs = fs
@@ -26,8 +38,10 @@ class AppController:
         self._root = root_dir
 
         # Pre-Load
-        img_view = ImageView(view._page_main, image_loader, config)
-        btn_panel = ButtonPanel(view._page_main, self._on_category_clicked, config, on_delete=self._on_delete_clicked)
+        img_view = ImageView(view._page_main, display_loader, config)
+        btn_panel = ButtonPanel(
+            view._page_main, self._on_category_clicked, config, on_delete=self._on_delete_clicked
+        )
         view.build_main(img_view, btn_panel)
 
         # Settings
@@ -52,7 +66,7 @@ class AppController:
             return
         target = self._root / name / src.name
         if self._fs.exists(target):
-            decision = CollisionDialog.prompt(self._view._root, self._image_loader, src, target)
+            decision = CollisionDialog.prompt(self._view._root, self._fast_loader, src, target)
             if decision.action == "keep_source":
                 self._fs.delete_file(target)
                 self._img_svc.move_current_to_category(name)


### PR DESCRIPTION
## Summary
- allow PillowImageLoader to accept custom resampling filters
- use separate LANCZOS and NEAREST loaders in main app
- update AppController to manage both loaders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51d9e12bc83279451f3e94d3ee723