### PR TITLE
Add auto-resolve conflict option

### DIFF
--- a/image_categorizer/config.py
+++ b/image_categorizer/config.py
@@ -11,6 +11,7 @@ class UiConfig:
     button_pady: int = 4
     image_bg: str = "#111111"
 
-@dataclass(frozen=True)
+@dataclass
 class AppConfig:
     ui: UiConfig = UiConfig()
+    auto_resolve_conflicts: bool = False

--- a/image_categorizer/ui/app_controller.py
+++ b/image_categorizer/ui/app_controller.py
@@ -66,16 +66,19 @@ class AppController:
             return
         target = self._root / name / src.name
         if self._fs.exists(target):
-            decision = CollisionDialog.prompt(self._view._root, self._fast_loader, src, target)
-            if decision.action == "keep_source":
-                self._fs.delete_file(target)
-                self._img_svc.move_current_to_category(name)
-            elif decision.action == "keep_target":
+            if self._cfg.auto_resolve_conflicts:
                 self._img_svc.delete_current()
-            elif decision.action == "rename":
-                self._img_svc.move_current_to_category_as(name, decision.new_name)
             else:
-                return
+                decision = CollisionDialog.prompt(self._view._root, self._fast_loader, src, target)
+                if decision.action == "keep_source":
+                    self._fs.delete_file(target)
+                    self._img_svc.move_current_to_category(name)
+                elif decision.action == "keep_target":
+                    self._img_svc.delete_current()
+                elif decision.action == "rename":
+                    self._img_svc.move_current_to_category_as(name, decision.new_name)
+                else:
+                    return
         else:
             cmd = MoveImageCommand(self._img_svc, name)
             cmd.execute()

--- a/image_categorizer/ui/settings_view.py
+++ b/image_categorizer/ui/settings_view.py
@@ -24,6 +24,15 @@ class SettingsView(ttk.Frame):
         ttk.Button(btns, text="Add", command=self._add).pack(side="left", padx=4)
         ttk.Button(btns, text="Delete", command=self._delete).pack(side="left", padx=4)
 
+        self._auto_resolve_var = tk.BooleanVar(value=self._config.auto_resolve_conflicts)
+        ttk.Checkbutton(
+            self,
+            text="Auto-delete on filename conflict",
+            variable=self._auto_resolve_var,
+            style="Switch.TCheckbutton",
+            command=self._on_auto_resolve_clicked,
+        ).grid(row=3, column=0, sticky="w", padx=6, pady=(0,6))
+
         self.refresh()
 
     def refresh(self):
@@ -49,3 +58,17 @@ class SettingsView(ttk.Frame):
             messagebox.showerror("Cannot Delete", f"Category '{name}' is not empty.")
         self.refresh()
         self._on_changed()
+
+    def _on_auto_resolve_clicked(self):
+        if self._auto_resolve_var.get():
+            ok = messagebox.askokcancel(
+                "Enable Auto-Resolve",
+                "Enabling this option will delete the source image if a file with the same name already exists in the target category.",
+            )
+            if ok:
+                self._config.auto_resolve_conflicts = True
+            else:
+                self._auto_resolve_var.set(False)
+                self._config.auto_resolve_conflicts = False
+        else:
+            self._config.auto_resolve_conflicts = False

--- a/tests/test_auto_resolve.py
+++ b/tests/test_auto_resolve.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy PIL modules so imports succeed without pillow installed
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+
+from image_categorizer.ui.app_controller import AppController
+from image_categorizer.config import AppConfig
+
+
+class DummyImageService:
+    def __init__(self):
+        self.deleted = False
+        self.moved = []
+
+    def current_image(self):
+        return Path("src.jpg")
+
+    def delete_current(self):
+        self.deleted = True
+
+    def move_current_to_category(self, name):
+        self.moved.append((name, None))
+
+    def move_current_to_category_as(self, name, new_name):
+        self.moved.append((name, new_name))
+
+
+class DummyFS:
+    def __init__(self, exists_return):
+        self.exists_return = exists_return
+        self.deleted_files = []
+
+    def exists(self, path):
+        return self.exists_return
+
+    def delete_file(self, path):
+        self.deleted_files.append(path)
+
+
+class DummyView:
+    def __init__(self):
+        self._root = None
+
+
+def build_controller(fs, cfg, img_svc):
+    controller = AppController.__new__(AppController)
+    controller._view = DummyView()
+    controller._logger = None
+    controller._display_loader = None
+    controller._fast_loader = None
+    controller._cat_svc = None
+    controller._img_svc = img_svc
+    controller._fs = fs
+    controller._cfg = cfg
+    controller._root = Path("/root")
+    controller._post_load = lambda *args, **kwargs: None
+    return controller
+
+
+def test_auto_resolve_deletes_source(monkeypatch):
+    img_svc = DummyImageService()
+    fs = DummyFS(exists_return=True)
+    cfg = AppConfig(auto_resolve_conflicts=True)
+    ctl = build_controller(fs, cfg, img_svc)
+    ctl._on_category_clicked("cats")
+    assert img_svc.deleted is True
+    assert img_svc.moved == []
+
+
+def test_collision_dialog_invoked_when_disabled(monkeypatch):
+    calls = []
+
+    def fake_prompt(parent, loader, src, target):
+        calls.append((parent, loader, src, target))
+
+        class D:
+            action = "cancel"
+            new_name = None
+
+        return D()
+
+    from image_categorizer.ui import app_controller as ac
+    monkeypatch.setattr(ac.CollisionDialog, "prompt", fake_prompt)
+
+    img_svc = DummyImageService()
+    fs = DummyFS(exists_return=True)
+    cfg = AppConfig(auto_resolve_conflicts=False)
+    ctl = build_controller(fs, cfg, img_svc)
+    ctl._on_category_clicked("cats")
+    assert calls
+    assert img_svc.deleted is False


### PR DESCRIPTION
## Summary
- allow enabling auto-resolve for filename conflicts via new config flag
- expose auto-resolve setting in UI with confirmation dialog
- skip collision dialog and delete source image when auto-resolve is active
- add tests covering auto-resolve behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52303eb5c8327a1aa6929696ea302