### PR TITLE
feat: add theme preferences and settings view

### DIFF
--- a/app.pyw
+++ b/app.pyw
@@ -1,7 +1,9 @@
 import tkinter as tk
+from tkinter import ttk
 from pathlib import Path
 from PIL import Image
 from image_categorizer.config import AppConfig
+from image_categorizer.preferences import load_preferences, Preferences
 from image_categorizer.infrastructure import (
     ConsoleLogger,
     LocalFileSystem,
@@ -12,9 +14,23 @@ from image_categorizer.infrastructure import (
 from image_categorizer.services import CategoryService, ImageService
 from image_categorizer.ui import MainView, AppController
 
+def _apply_theme(root: tk.Tk, theme: str) -> None:
+    style = ttk.Style(root)
+    if theme == "dark":
+        style.theme_use("clam")
+        style.configure(".", background="#333333", foreground="white")
+        root.configure(bg="#333333")
+    elif theme == "light":
+        style.theme_use("clam")
+        style.configure(".", background="#f0f0f0", foreground="black")
+        root.configure(bg="#f0f0f0")
+
+
 def main():
-    cfg = AppConfig()
+    prefs: Preferences = load_preferences()
+    cfg = AppConfig(theme=prefs.theme)
     root = tk.Tk()
+    _apply_theme(root, cfg.theme)
     view = MainView(root, cfg)
 
     chosen = view.ask_root_dir()

--- a/image_categorizer/config.py
+++ b/image_categorizer/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, Literal
 
 SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".webp"}
 
@@ -15,3 +15,4 @@ class UiConfig:
 class AppConfig:
     ui: UiConfig = UiConfig()
     auto_resolve_conflicts: bool = False
+    theme: Literal["light", "system", "dark"] = "system"

--- a/image_categorizer/data/preferences.json
+++ b/image_categorizer/data/preferences.json
@@ -1,0 +1,3 @@
+{
+  "theme": "system"
+}

--- a/image_categorizer/preferences.py
+++ b/image_categorizer/preferences.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+PREF_PATH = Path(__file__).resolve().parent / "data" / "preferences.json"
+
+
+@dataclass
+class Preferences:
+    theme: Literal["light", "system", "dark"] = "system"
+
+
+def load_preferences() -> Preferences:
+    """Load preferences from disk.
+
+    Returns default values when the file does not exist or is invalid.
+    """
+    try:
+        with PREF_PATH.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return Preferences(theme=data.get("theme", "system"))
+    except FileNotFoundError:
+        return Preferences()
+    except Exception:
+        # If the file is corrupt, fall back to defaults
+        return Preferences()
+
+
+def save_preferences(prefs: Preferences) -> None:
+    """Persist the provided preferences to disk."""
+    PREF_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with PREF_PATH.open("w", encoding="utf-8") as fh:
+        json.dump({"theme": prefs.theme}, fh)

--- a/image_categorizer/ui/app_controller.py
+++ b/image_categorizer/ui/app_controller.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 from ..interfaces.logger import ILogger
 from ..interfaces.image_loader import IImageLoader
 from ..interfaces.services import ICategoryService, IImageService
@@ -11,6 +11,7 @@ from .main_view import MainView
 from .image_view import ImageView
 from .button_panel import ButtonPanel
 from .settings_view import SettingsView
+from .user_settings_view import UserSettingsView
 from .collision_dialog import CollisionDialog
 
 
@@ -47,10 +48,15 @@ class AppController:
         # Settings
         settings = SettingsView(view._page_settings, self._cat_svc, self._cfg, on_changed=self._refresh_categories)
         view.place_settings(settings)
+        user_settings = UserSettingsView(
+            view._page_user_settings, self._cfg, on_theme_changed=self._apply_theme
+        )
+        view.place_user_settings(user_settings)
 
         # On Load
         self._refresh_categories()
         self._post_load(initial=True)
+        self._apply_theme(self._cfg.theme)
 
     def _on_delete_clicked(self):
         path = self._img_svc.current_image()
@@ -106,3 +112,16 @@ class AppController:
             self._view.error("Image Load Error", str(ex))
 
         self._view.set_remaining_count(self._img_svc.count_images())
+
+    def _apply_theme(self, theme: str) -> None:
+        style = ttk.Style(self._view._root)
+        if theme == "dark":
+            style.theme_use("clam")
+            style.configure(".", background="#333333", foreground="white")
+            self._view._root.configure(bg="#333333")
+        elif theme == "light":
+            style.theme_use("clam")
+            style.configure(".", background="#f0f0f0", foreground="black")
+            self._view._root.configure(bg="#f0f0f0")
+        else:
+            style.theme_use(style.theme_use())

--- a/image_categorizer/ui/main_view.py
+++ b/image_categorizer/ui/main_view.py
@@ -19,8 +19,10 @@ class MainView(ttk.Frame):
         self._nb = ttk.Notebook(self)
         self._page_main = ttk.Frame(self._nb)
         self._page_settings = ttk.Frame(self._nb)
+        self._page_user_settings = ttk.Frame(self._nb)
         self._nb.add(self._page_main, text="Categorize")
         self._nb.add(self._page_settings, text="Settings")
+        self._nb.add(self._page_user_settings, text="User Settings")
         self._nb.pack(fill="both", expand=True)
 
         self._page_main.rowconfigure(0, weight=1)
@@ -47,6 +49,9 @@ class MainView(ttk.Frame):
 
     def place_settings(self, widget: tk.Widget) -> None:
         widget.pack(fill="both", expand=True, in_=self._page_settings)
+
+    def place_user_settings(self, widget: tk.Widget) -> None:
+        widget.pack(fill="both", expand=True, in_=self._page_user_settings)
 
     def ask_root_dir(self) -> Optional[Path]:
         path = filedialog.askdirectory(title="Select Root Directory (images in root; subfolders = categories)")

--- a/image_categorizer/ui/user_settings_view.py
+++ b/image_categorizer/ui/user_settings_view.py
@@ -1,0 +1,31 @@
+import tkinter as tk
+from tkinter import ttk
+
+from ..config import AppConfig
+from ..preferences import save_preferences, Preferences
+
+
+class UserSettingsView(ttk.Frame):
+    def __init__(self, parent, config: AppConfig, on_theme_changed):
+        super().__init__(parent)
+        self._config = config
+        self._on_theme_changed = on_theme_changed
+
+        self.columnconfigure(0, weight=1)
+
+        self._theme_var = tk.StringVar(value=self._config.theme)
+        options = [("Light", "light"), ("System", "system"), ("Dark", "dark")]
+        for idx, (label, value) in enumerate(options):
+            rb = ttk.Radiobutton(
+                self,
+                text=label,
+                value=value,
+                variable=self._theme_var,
+                command=self._theme_selected,
+            )
+            rb.grid(row=0, column=idx, padx=6, pady=6, sticky="w")
+
+    def _theme_selected(self) -> None:
+        self._config.theme = self._theme_var.get()
+        save_preferences(Preferences(theme=self._config.theme))
+        self._on_theme_changed(self._config.theme)


### PR DESCRIPTION
## Summary
- add preferences module to persist user theme
- allow app configuration to include light/system/dark theme
- introduce User Settings tab for runtime theme switching and saving

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5252e11908327beaca153a94de1a2