### PR TITLE
Make button layout responsive to container width

### DIFF
--- a/image_categorizer/config.py
+++ b/image_categorizer/config.py
@@ -6,7 +6,6 @@ SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".webp
 @dataclass(frozen=True)
 class UiConfig:
     min_window_size: Tuple[int, int] = (900, 700)
-    buttons_per_row: int = 5
     button_padx: int = 4
     button_pady: int = 4
     image_bg: str = "#111111"

--- a/image_categorizer/ui/button_panel.py
+++ b/image_categorizer/ui/button_panel.py
@@ -53,7 +53,7 @@ class ButtonPanel(ttk.Frame):
             return
 
         inner = self._scroll.inner
-        width = self._scroll.canvas.winfo_width()
+        width = event.width if event else inner.winfo_width()
         if width <= 0:
             return
 

--- a/image_categorizer/ui/button_panel.py
+++ b/image_categorizer/ui/button_panel.py
@@ -14,7 +14,9 @@ class ButtonPanel(ttk.Frame):
 
         self._scroll = ScrollableFrame(self)
         self._scroll.grid(row=0, column=0, sticky="nsew")
+        # Reflow when the inner frame or its canvas changes size
         self._scroll.inner.bind("<Configure>", self._reflow_buttons, add="+")
+        self._scroll.canvas.bind("<Configure>", self._reflow_buttons, add="+")
 
         footer = ttk.Frame(self)
         footer.grid(row=1, column=0, sticky="ew", pady=(6,0))
@@ -51,7 +53,7 @@ class ButtonPanel(ttk.Frame):
             return
 
         inner = self._scroll.inner
-        width = inner.winfo_width()
+        width = self._scroll.canvas.winfo_width()
         if width <= 0:
             return
 

--- a/image_categorizer/utils/tk_helpers.py
+++ b/image_categorizer/utils/tk_helpers.py
@@ -12,7 +12,11 @@ class ScrollableFrame(ttk.Frame):
         self.inner = ttk.Frame(self.canvas)
 
         self.inner.bind("<Configure>", lambda e: self.canvas.configure(scrollregion=self.canvas.bbox("all")))
-        self.canvas.create_window((0, 0), window=self.inner, anchor="nw")
+        self._inner_id = self.canvas.create_window((0, 0), window=self.inner, anchor="nw")
+        self.canvas.bind(
+            "<Configure>",
+            lambda e: self.canvas.itemconfig(self._inner_id, width=e.width),
+        )
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
         self.apply_theme()
 


### PR DESCRIPTION
## Summary
- Drop fixed `buttons_per_row` config and rely on dynamic layout
- Add `_reflow_buttons` in `ButtonPanel` to compute columns based on container width
- Reflow buttons on parent resize and expand columns with weight 1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52b983a808327b045191d73a3fe7e